### PR TITLE
Add precautions for directory tree removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ES-DOC command line shell
 What is ES-DOC ?
 --------------------------------------
 
-ES-DOC stands for Earth Science - Documentation.  It's goal is to provide software tools and services in order to support the distribution of earth science documentation.
+ES-DOC stands for Earth Science - Documentation.  Its goal is to provide software tools and services in order to support the distribution of earth science documentation.
 
 
 What is esdoc-shell ?
@@ -25,7 +25,7 @@ There is a need to support command line programs for streamlining deployments, p
 Who uses esdoc-shell ?
 --------------------------------------
 
-Anyone who wishes to install and use es-doc tools & api's from the command line.
+Anyone who wishes to install and use es-doc tools & APIs from the command line.
 
 
 Installation

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -49,8 +49,10 @@ log_banner()
 # Resets temporary folder.
 reset_tmp()
 {
-	rm -rf $ESDOC_DIR_TMP/*
-	mkdir -p $ESDOC_DIR_TMP
+        if [ ! -z "${ESDOC_DIR_TMP}" ]; then
+                rm -rf $ESDOC_DIR_TMP/*
+                mkdir -p $ESDOC_DIR_TMP
+        fi
 }
 
 # Assigns the current working directory.

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -51,11 +51,14 @@ reset_tmp()
 {
         if [ ! -z "${ESDOC_DIR_TMP}" ]; then
             echo "About to remove all directories under ${ESDOC_DIR_TMP}"
-            echo "3 seconds to cancel before removal..."
+            echo "3 seconds to cancel before starting removal..."
             sleep 3
             rm -r $ESDOC_DIR_TMP/*
 
             mkdir -p $ESDOC_DIR_TMP
+        else
+            echo "ESDOC_DIR_TMP variable is not set so doing nothing"
+            echo "Ensure ESDOC_DIR_TMP is set for reset_tmp to function"
         fi
 }
 

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -50,8 +50,12 @@ log_banner()
 reset_tmp()
 {
         if [ ! -z "${ESDOC_DIR_TMP}" ]; then
-                rm -rf $ESDOC_DIR_TMP/*
-                mkdir -p $ESDOC_DIR_TMP
+            echo "About to remove all directories under ${ESDOC_DIR_TMP}"
+            echo "3 seconds to cancel before removal..."
+            sleep 3
+            rm -r $ESDOC_DIR_TMP/*
+
+            mkdir -p $ESDOC_DIR_TMP
         fi
 }
 


### PR DESCRIPTION
Close #5, including conveying intent by message and then waiting for 3 seconds as pre-caution even when the env. var. in question,  `$ESDOC_DIR_TMP` , is defined. Can't be too careful with an under-the-hood recursive `rm` command!